### PR TITLE
Support USB microcontrollers (like Pi Pico)

### DIFF
--- a/boot/samplerbox/changelist.txt
+++ b/boot/samplerbox/changelist.txt
@@ -12,9 +12,14 @@ Feb-Mar 2021:
   - Changed /samples partition on image to NTFS
     - it can be accessed from windows
     - changed remount procedure for updating set configuration files, placed this in 
-    - new general procedure module (other subs will be moved there later)
+    - new general procedure module gp.py (other subs will be moved there later)
+    - improved test on running from SD image (on SD readonly is assumed, thus requiring remounts)
   - Extra examples in wifistatips (also contains example for fixed wired address)
   - Bugfix mode=once: subsequent keypress now restarts again as intended/documented
+  - If a USB storage device contains no potential samplesets, the internal SD space will be used.
+    - valid for microcontrollers using USB both for programming and MIDI, e.g. Pi Pico.
+    - potential samplesets are recognized by name starting with digits followed by a space.
+    - yes, this is mutually exclusive and not 100% fool proof. Consider serial midi...
 Sept-Nov 2020:
   - Extended midimon.py to support serial midi
   - Fixed bug for LED's (red blinking when all is OK)

--- a/boot/samplerbox/configuration.txt
+++ b/boot/samplerbox/configuration.txt
@@ -27,6 +27,7 @@ BLOCKSIZE = High                ; Blocksize or "Low"/"High". High may cause late
 USE_48kHz = False               ; Sets audio to 48000Hz while keeping wav's on 44100Hz. Try to avoid this...
 USE_SERIALPORT_MIDI = False     ; Set to True to enable MIDI IN via SerialPort (e.g. RaspberryPi's GPIO UART pins)
 USE_HD44780_16x2_LCD = False    ; Set to True to use a 16x2 direct connected/wired HD44780 LCD
+#                                 If you use an I2C-HD44780, above option should be false !!!
 USE_I2C_LCD = False             ; Set to True or 16x2 (=True) or 20x4 to use a 16x2 or 20x4 I2C connected HD44780 LCD
 USE_OLED = False                ; Set to True to use an OLED display !!! Configure below
 USE_I2C_7SEGMENTDISPLAY = False ; Set to True to use a 7-segment display via I2C

--- a/modules/gp.py
+++ b/modules/gp.py
@@ -8,14 +8,20 @@
 import gv, subprocess
 
 def samples2write():
-	if gv.rootprefix=="":
-		print ( "Remount samplesdir as RW" )
-		subprocess.call( ['umount', gv.samplesdir] )
-		subprocess.call( ['mount', '/dev/mmcblk0p3', gv.samplesdir] )
+	if gv.RUN_FROM_IMAGE:
+		print ( "Remount %s as RW" %gv.samplesdir)
+		if ( gv.samplesdir == gv.SAMPLES_ONUSB ):
+			subprocess.call( ['mount', '-vo', 'remount,rw', gv.samplesdir] )
+		else:
+			subprocess.call( ['umount', gv.samplesdir] )
+			subprocess.call( ['mount', '-v', '/dev/mmcblk0p3', gv.samplesdir] )
 	else:
 		print ("Not running dedicated, so no remount as we're most likely already R/W")
 def samples2read():
-	if gv.rootprefix=="":
-		print ( "Remount samplesdir as RO" )
-		subprocess.call( ['umount', gv.samplesdir] )
-		subprocess.call( ['mount', '-r', '/dev/mmcblk0p3', gv.samplesdir] )
+	if gv.RUN_FROM_IMAGE:
+		print ( "Remount %s as RO" %gv.samplesdir )
+		if ( gv.samplesdir == gv.SAMPLES_ONUSB ):
+			subprocess.call(['mount', '-vo', 'remount,ro', gv.samplesdir])
+		else:
+			subprocess.call( ['umount', gv.samplesdir] )
+			subprocess.call( ['mount', '-vr', '/dev/mmcblk0p3', gv.samplesdir] )


### PR DESCRIPTION
If a USB storage device contains no potential samplesets, the internal SD space will be used.
    - valid for microcontrollers using USB both for programming and MIDI, e.g. Pi Pico.
    - potential samplesets are recognized by name starting with digits followed by a space.
    - yes, this is mutually exclusive and not 100% fool proof. Consider serial midi...