### PR TITLE
Working Pimoroni PirateAudio support.

### DIFF
--- a/boot/config.txt
+++ b/boot/config.txt
@@ -5,7 +5,7 @@ max_usb_current=1
 disable_splash=1
 disable_audio_dither=1
 #
-# for enabling SPI interface (like used by OLED) uncomment next parm
+# for enabling SPI interface (like used by OLED or PIM_LCD) uncomment next parm
 #dtparam=spi=on
 #
 # for enabling the serial midi port (DIY 5-pole DIN) uncomment:
@@ -21,3 +21,5 @@ dtparam=audio=on
 #dtoverlay=hifiberry-dacplus
 #dtoverlay=hifiberry-digi
 #dtoverlay=hifiberry-amp
+# for Pimoroni PirateAudio uncomment the following
+# pio=25=op,dh

--- a/boot/samplerbox/configuration.txt
+++ b/boot/samplerbox/configuration.txt
@@ -30,6 +30,7 @@ USE_HD44780_16x2_LCD = False    ; Set to True to use a 16x2 direct connected/wir
 #                                 If you use an I2C-HD44780, above option should be false !!!
 USE_I2C_LCD = False             ; Set to True or 16x2 (=True) or 20x4 to use a 16x2 or 20x4 I2C connected HD44780 LCD
 USE_OLED = False                ; Set to True to use an OLED display !!! Configure below
+USE_PIMORONI_LCD = False         ; Set True to use a 16x2Pimoroni PirateAudio hat !!! Configure below
 USE_I2C_7SEGMENTDISPLAY = False ; Set to True to use a 7-segment display via I2C
 USE_BUTTONS = False             ; Set to True to use the GPIO buttons
 USE_LEDS = False                ; Set to True to use LED's connected to RaspberryPi's GPIO pins
@@ -84,8 +85,8 @@ PITCHBITS = 7                   ; pitchwheel resolution, 0=disable, max=14 (=163
 #     -- EEPROM      : 0,1
 #     -- Serial Port : 14,15
 #     -- I2C         : 2,3
-#     -- HiFiBerry   : 2,3,18,19,20,21      
-#
+#     -- HiFiBerry   : 2,3,18,19,20,21     
+#     -- PirateAudio Hat :  5 (Button A), 6 (Button B), 16 (Button X), 24 (Button Y)
 #     -- USE_BUTTONS --		; A valid GPIO value will activate the button
 BUT_incr=05                     ; Increase button, increases value/proceeds to next menu choice
 BUT_decr=13                     ; Decrease button, opposite of above. In 3-button setup it will return from submenu
@@ -118,6 +119,15 @@ OLED_WIDTH=128                  ; width of the display in pixels
 OLED_HEIGHT=64                  ; height of the display in pixels
 OLED_PADDING=-2                 ; padding around the display content, important for readability
 #
+#     -- USE_PIMORONI_LCD -- LCD connection and device settings (SPI connection)
+PIM_LCD_DRIVER = ST7789         ; Set to the correct Lcd driver chip, one of: SH1106 or SSD1306 (more to come)
+PIM_LCD_BL=13                   ; Backlight pin
+PIM_LCD_CS=1                    ; Chips select pin
+PIM_LCD_DC=9                    ; data/command pin
+PIM_LCD_PORT=0                  ; LCD device port, default should be fine
+PIM_LCD_WIDTH=240               ; width of the display in pixels
+PIM_LCD_HEIGHT=240              ; height of the display in pixels
+PIM_LCD_PADDING=-2              ; padding around the display content, important for readability
 ########  Default filter values ########
 #         R E V E R B
 Reverb=Off                      ; Default state of the reverb (On/Off)

--- a/modules/PIM_LCD.py
+++ b/modules/PIM_LCD.py
@@ -1,0 +1,104 @@
+###############################################################
+#  LCD display via SPI interface adapted from OLED.py
+#
+#  Currently supports only Pimoroni st7789 LCD driver
+#  but is (as ws the OLED.py) extensible.
+#  Please contact me (Hans) if you have or need additions !
+#
+#   SamplerBox extended by HansEhv (https://github.com/hansehv)
+###############################################################
+# -*- coding:utf-8 -*-
+
+from PIL import Image
+from PIL import ImageDraw
+from PIL import ImageFont
+
+import UI
+import gv
+driver = gv.cp.get(gv.cfg, "PIM_LCD_DRIVER".lower())
+if driver == "ST7789":
+    from ST7789 import ST7789
+
+
+SPI_SPEED_MHZ = 80
+
+
+class pim_lcd:
+    def __init__(self):
+        self.busy = False
+        self.s4 = ''
+        self.s5 = ''
+        self.s6 = ''
+        # Parse config for display settings
+        BL = gv.cp.getint(gv.cfg, "PIM_LCD_BL".lower())
+        CS = gv.cp.getint(gv.cfg, "PIM_LCD_CS".lower())
+        DC = gv.cp.getint(gv.cfg, "PIM_LCD_DC".lower())
+        port = gv.cp.getint(gv.cfg, "PIM_LCD_PORT".lower())
+        print("Starting LCD %s, using SPI port %d and GPIO BL=%d, CS=%d, DC=%d"
+              % (driver, port, BL, CS, DC))
+
+        # Load default font.
+        #self.font = ImageFont.load_default()
+        self.font = ImageFont.truetype("/root/SamplerBox/modules/DejaVuSans.ttf",28)
+        # Create blank image for drawing.
+        # Make sure to create image with mode '1' for 1-bit color.
+        self.width = gv.cp.getint(gv.cfg, "PIM_LCD_WIDTH".lower())
+        self.height = gv.cp.getint(gv.cfg, "PIM_LCD_HEIGHT".lower())
+        self.image = Image.new("RGB", (self.width, self.height), (0, 0, 0))
+        self.draw = ImageDraw.Draw(self.image)
+
+        # First define some constants to allow easy resizing of shapes.
+        self.padding = gv.cp.getint(gv.cfg, "PIM_LCD_PADDING".lower())
+        self.top = self.padding
+        self.bottom = self.height-self.padding
+        # Move left to right keeping track of the current x position for drawing shapes.
+        self.x = 0
+
+        if driver == "ST7789":
+            self.device = ST7789(
+                                rotation=90,   # Needed to display the right way up on Pirate Audio
+                                port=port,     # SPI port
+                                cs=CS,         # SPI port Chip-select channel
+                                dc=DC,         # BCM pin used for data/command
+                                backlight=BL,
+                                spi_speed_hz=SPI_SPEED_MHZ * 1000 * 1000)
+        else:
+            print("Wrong driver")
+
+    def display(self, msg, menu1, menu2, menu3):
+        if self.busy: 
+            return False
+        self.busy = True
+        # #########START DRAWING##########################
+        self.draw.rectangle((0, 0, self.device.width-1, self.device.height-1), fill=(0,0,0))
+        if UI.USE_ALSA_MIXER:
+            s1 = "%s | Vol: %d%%" % (UI.Mode(), UI.SoundVolume())
+        else:
+            s1 = "Mode: %s" % (gv.sample_mode)
+        s2 = msg
+        if s2 == '':
+            if UI.Voice() > 1:
+                s2 = str(UI.Voice()) + ":"
+            if UI.Presetlist() != []:
+                s2 += UI.Presetlist()[UI.getindex(UI.Preset(), UI.Presetlist())][1]
+
+        s3a = "Scale:%s" % (UI.Scalename()[UI.Scale()])
+        s3b = "Chord:%s" % (UI.Chordname()[UI.Chord()])
+        # Change menu lines if necessary
+        if menu1 != '':
+            self.s4 = menu1
+            self.s5 = menu2
+            self.s6 = menu3
+        s6 = self.s6 if self.s6 != '' else UI.IP()
+        self.draw.text((self.x, self.top), s1, font=self.font, fill=(128,255,0))
+        self.draw.rectangle((self.x, self.top + 28, self.device.width, self.top + 30), fill=(255,255,255))
+        self.draw.text((self.x+2, self.top+32), s2, font=self.font, fill=(255,255,255))
+        self.draw.text((self.x, self.top+60), s3a, font=self.font, fill=(255,255,255))
+        self.draw.text((self.x, self.top+84), s3b, font=self.font, fill=(255,255,255))
+        self.draw.text((self.x, self.top+112), self.s4, font=self.font, fill=(255,128,0))
+        self.draw.text((self.x, self.top+140), self.s5, font=self.font, fill=(255,128,0))
+        self.draw.text((self.x, self.top+168), s6, font=self.font, fill=(0,128,255))
+        self.device.display(self.image)
+        # #########END DRAWING##########################
+        self.busy = False
+        return True

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -320,6 +320,14 @@ try:
             oled.display(msg,menu1,menu2,menu3)
         display('Start Samplerbox')
 
+    elif gv.cp.getboolean(gv.cfg,"USE_PIMORONI_LCD".lower()):
+        USE_GPIO=True
+        import PIM_LCD
+        pimlcd = PIM_LCD.pim_lcd()
+        def display(msg='',msg7seg='',menu1='',menu2='',menu3='',*z):
+            pimlcd.display(msg,menu1,menu2,menu3)
+        display('Start Samplerbox')
+
     elif gv.cp.getboolean(gv.cfg,"USE_I2C_7SEGMENTDISPLAY".lower()):
         import I2C_7segment
         def display(msg,msg7seg='',*z):


### PR DESCRIPTION
Added PIM_LCD.py. 

- Displayed font is created from a hatdcoded font file at "/root/SamplerBox/modules/DejaVuSans.ttf". This is the standard free DejaVuSans font *
- Display is 240 x 240 and line s3 (Scale: Chord:)has been split over two lines  to beter make use of the vertical space with a large font

The running display is [depicted here](https://photos.app.goo.gl/YdHFt99pL3c8iDdZ8)

(*It might be better to make the font configurable)