### PR TITLE
I2C support for OLED displays

### DIFF
--- a/config/configuration.txt
+++ b/config/configuration.txt
@@ -50,9 +50,9 @@ USE_HD44780_16x2_LCD = False
 ## Set True or 16x2 (=True) or 20x4 to use a 16x2 or 20x4 I2C connected HD44780 LCD
 USE_I2C_LCD = False
 ## Set True to use an OLED display, configure GPIO pins below
-USE_OLED = True
+USE_OLED = False
 ## Set to: SPI or I2C
-OLED_PROTOCOL = I2C 
+OLED_PROTOCOL = SPI
 ## Set True to use LCD of Pimoroni PirateAudio hat. Configure GPIO pins below
 USE_PIMORONI_LCD = False
 ## Set True to use a 7-segment display via I2C
@@ -226,7 +226,7 @@ OLED_ROTATE=2
 #     -- OLED_PROTOCOL = SPI -- connection and device settings (SPI connection)
 # Set to the correct OLED driver chip, one of: SH1106 or SSD1306 (more to come)
 # RSt=Reset, CS=ChipsSelect, DC=data/command
-OLED_DRIVER = SSD1306
+OLED_DRIVER = SH1106
 OLED_RST=25
 OLED_CS=8
 OLED_DC=24

--- a/config/configuration.txt
+++ b/config/configuration.txt
@@ -50,7 +50,9 @@ USE_HD44780_16x2_LCD = False
 ## Set True or 16x2 (=True) or 20x4 to use a 16x2 or 20x4 I2C connected HD44780 LCD
 USE_I2C_LCD = False
 ## Set True to use an OLED display, configure GPIO pins below
-USE_OLED = False
+USE_OLED = True
+## Set to: SPI or I2C
+OLED_PROTOCOL = I2C 
 ## Set True to use LCD of Pimoroni PirateAudio hat. Configure GPIO pins below
 USE_PIMORONI_LCD = False
 ## Set True to use a 7-segment display via I2C
@@ -213,20 +215,28 @@ LCD_D7=4
 I2C_LCD_ADDR=0x3f
 I2C_LCD_PORT=1
 
-#     -- USE_OLED -- OLED connection and device settings (SPI connection)
-# Set to the correct OLED driver chip, one of: SH1106 or SSD1306 (more to come)
-# RSt=Reset, CS=ChipsSelect, DC=data/command
+
+#     -- USE_OLED -- OLED display settings
 # ROTATE: 0, 1, 2 or 3 only, respectively 0, 90, 180, 270 degrees clockwise.
-#
-OLED_DRIVER = SH1106
-OLED_RST=25
-OLED_CS=8
-OLED_DC=24
-OLED_PORT=0
 OLED_WIDTH=128
 OLED_HEIGHT=64
 OLED_PADDING=-2
 OLED_ROTATE=2
+
+#     -- OLED_PROTOCOL = SPI -- connection and device settings (SPI connection)
+# Set to the correct OLED driver chip, one of: SH1106 or SSD1306 (more to come)
+# RSt=Reset, CS=ChipsSelect, DC=data/command
+OLED_DRIVER = SSD1306
+OLED_RST=25
+OLED_CS=8
+OLED_DC=24
+OLED_PORT=0
+
+#     -- OLED_PROTOCOL = I2C -- connection and device settings (I2C connection)
+# Set to the correct OLED driver chip, one of: SH1106 or SSD1306 (more to come)
+OLED_I2C_DRIVER = SSD1306
+OLED_I2C_PORT=1
+OLED_I2C_ADDRESS=0x3c
 
 #     -- USE_PIMORONI_LCD -- LCD connection and device settings (SPI connection)
 # BL=Backlight pin, CS=Chips select pin, DC=data/command pin

--- a/modules/OLED.py
+++ b/modules/OLED.py
@@ -40,7 +40,15 @@ class oled:
         CS = gv.cp.getint(gv.cfg,"OLED_CS".lower())
         DC = gv.cp.getint(gv.cfg,"OLED_DC".lower())
         port = gv.cp.getint(gv.cfg,"OLED_PORT".lower())
-        print( "Starting OLED %s, using SPI port %d and GPIO RST=%d, CS=%d, DC=%d" %(driver, port, RST, CS, DC) )
+        protocol = gv.cp.get(gv.cfg,"OLED_PROTOCOL".lower())
+        i2c_address = int(gv.cp.get(gv.cfg,"OLED_I2C_ADDRESS".lower()),16)
+        i2c_port = gv.cp.getint(gv.cfg,"OLED_I2C_PORT".lower())
+        print( "Starting OLED %s, using protocol %s" %(driver, protocol) )
+        if protocol=="SPI":
+            print ("   on Port %d, and GPIO RST=%d, CS=%d, DC=%d" %(port, RST, CS, DC) )
+        if protocol=="I2C":
+            print ("   on Port %d, I2C target address %d" %(i2c_port, i2c_address) )
+
         # Load default font.
         self.font = ImageFont.load_default()
         
@@ -57,8 +65,11 @@ class oled:
         self.bottom = self.height-self.padding
         # Move left to right keeping track of the current x position for drawing shapes.
         self.x = 0
-        serial = spi(device=port, port=port, bus_speed_hz = 8000000, transfer_size = 4096, gpio_DC = DC, gpio_RST = RST)
-        
+        if protocol=="SPI":
+            serial = spi(device=port, port=port, bus_speed_hz = 8000000, transfer_size = 4096, gpio_DC = DC, gpio_RST = RST)
+        elif protocol=="I2C":
+            serial = i2c(port=i2c_port, address=i2c_address)
+
         rot = gv.cp.getint(gv.cfg,"OLED_ROTATE".lower())
         if driver=="SH1106":
             self.device = sh1106(serial, rotate=rot)


### PR DESCRIPTION
I added I2C support for OLED displays since I needed it by myself.
Here is a example display that is working with the configuration:
 https://www.az-delivery.de/products/0-96zolldisplay
I left the name of the OLED SPI variables as they were, so there should be no need of changes when upgrading.
A test on this branch if OLED SPI displays are still working would be nice (don't have one by myself), since I'm pretty new to python.